### PR TITLE
Add tensorflow-gpu to list of requirements

### DIFF
--- a/requirements/aind-dog-linux.yml
+++ b/requirements/aind-dog-linux.yml
@@ -59,6 +59,7 @@ dependencies:
   - simplegeneric==0.8.1
   - six==1.10.0
   - tensorflow==1.0.0
+  - tensorflow-gpu==1.0.0
   - terminado==0.6
   - testpath==0.3.1
   - theano==0.9.0

--- a/requirements/aind-dog-mac.yml
+++ b/requirements/aind-dog-mac.yml
@@ -200,5 +200,6 @@ dependencies:
   - rope-py3k==0.9.4.post1
   - tables==3.3.0
   - tensorflow==1.0.0
+  - tenforflow-gpu==1.0.0
   - theano==0.8.2
   - tqdm==4.11.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,3 +8,4 @@ keras==2.0.2
 scikit-learn==0.18.1
 pillow==4.0.0
 tensorflow==1.0.0
+tensorflow-gpu==1.0.0


### PR DESCRIPTION
If tensorflow-gpu is not installed, the PC will not take advantage of the GPU even if it has one. This will slow down students' code significantly.